### PR TITLE
Remove test from receipt-data

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -24,7 +24,7 @@ export default function(password, production=true) {
 
   return async (receipt) => {
     const payload = {
-      'receipt-data': receipt + 'test',
+      'receipt-data': receipt,
       password,
     };
 


### PR DESCRIPTION
Removes `test` from string data resulting in a `21002`  status code.