### PR TITLE
Status Code 21006 should not throw an error.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,7 @@ const statusCodes = {
   [21003]: { message: 'Receipt not authenticated', valid: false, error: true },
   [21004]: { message: 'Shared secret does not match', valid: false, error: true },
   [21005]: { message: 'Receipt server unavailable', valid: false, error: true },
-  [21006]: { message: 'Receipt valid but sub expired', valid: false, error: false },
+  [21006]: { message: 'Receipt valid but sub expired', valid: true, error: false },
   /**
    * special case for app review handling - forward any request that is intended for the Sandbox but was sent to
    * Production, this is what the app review team does

--- a/src/index.js
+++ b/src/index.js
@@ -43,7 +43,7 @@ export default function (password, production = true) {
     const res = await fetch(verifyUrl, options);
     const body = await res.json();
 
-    if (body.status !== 0) {
+    if (body.status !== 0 && body.status !== 21006) {
       throw new VerificationError(statusCodes[body.status]);
     }
 


### PR DESCRIPTION
According to Validating Receipts With the App Store ( https://developer.apple.com/library/content/releasenotes/General/ValidateAppStoreReceipt/Chapters/ValidateRemotely.html#//apple_ref/doc/uid/TP40010573-CH104-SW1 ), the status code 21006 indicates that `This receipt is valid but the subscription has expired. When this status code is returned to your server, the receipt data is also decoded and returned as part of the response.` 

I believe that this response should be passed as a valid response since some users will need to access the dates of expired subscriptions.

Solves issue: https://github.com/sibelius/iap-receipt-validator/issues/14