### PR TITLE
Use application/json in content type header

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -36,7 +36,7 @@ export default function (password, production = true) {
       body: JSON.stringify(payload),
       method: 'POST',
       headers: {
-        'Content-Type': 'application/x-www-form-urlencoded',
+        'Content-Type': 'application/json',
       },
     };
 


### PR DESCRIPTION
iTunes expects the content of the POST request to be a JSON object. From my tests, it seems that they do not actually check the `Content-Type` header to determine if we are sending a JSON object. Hence, setting the content type as `application/x-www-form-urlencoded' also works. However, it would be semantic and helpful for anyone looking at this library as an example implementation to not have this misleading line.

I have personally spent considerable time trying to send actual form encoded data to iTunes because I saw the content type here. :)